### PR TITLE
fix compile errors

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,8 +126,10 @@ pub fn addTestBench(
     const zubench_dep = b.dependencyFromBuildZig(@This(), .{});
     const zubench_mod = zubench_dep.module("zubench");
     const bench_runner_path: std.Build.LazyPath = .{
-        .dependency = zubench_dep,
-        .sub_path = "src/bench_runner.zig",
+        .dependency = .{
+            .dependency = zubench_dep,
+            .sub_path = "src/bench_runner.zig",
+        },
     };
     return addTestBenchInner(b, path, mode, zubench_mod, bench_runner_path);
 }

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -89,8 +89,7 @@ pub const Samples = struct {
 fn startCounters() !Counters {
     var counters: Counters = undefined;
     for (&counters, sample_spec) |*counter, spec_elt| {
-        const clock_id = spec_elt.clockID();
-        counter.* = try time.Timer.start(clock_id);
+        counter.* = try time.Timer.start(spec_elt);
     }
     return counters;
 }

--- a/src/time.zig
+++ b/src/time.zig
@@ -2,74 +2,41 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
 
-const ns_per_s = 1_000_000_000;
-
 pub const Clock = enum {
     real,
     process,
     thread,
 
-    pub fn clockID(self: Clock) posix.clockid_t {
-        return switch (self) {
+    pub fn now(self: Clock) error{Unsupported}!std.time.Instant {
+        if (posix.CLOCK == void) return .now();
+        const clock_id = switch (self) {
             .real => switch (builtin.os.tag) {
                 .macos, .ios, .tvos, .watchos => posix.CLOCK.UPTIME_RAW,
                 .freebsd, .dragonfly => posix.CLOCK.MONOTONIC_FAST,
                 .linux => posix.CLOCK.BOOTTIME,
-                .windows => @compileError("windows is not supported"),
                 else => posix.CLOCK.MONOTONIC,
             },
             .process => posix.CLOCK.PROCESS_CPUTIME_ID,
             .thread => posix.CLOCK.THREAD_CPUTIME_ID,
         };
-    }
-};
-
-// this is an adaptation of std.time.Instant
-pub const Instant = struct {
-    timestamp: posix.timespec,
-
-    /// Queries the system for the current moment of time as an Instant.
-    /// This is not guaranteed to be monotonic or steadily increasing, but for most implementations it is.
-    /// Returns `error.Unsupported` when a suitable clock is not detected.
-    pub fn now(clock_id: posix.clockid_t) error{Unsupported}!Instant {
-        const ts = posix.clock_gettime(clock_id) catch return error.Unsupported;
-        return Instant{ .timestamp = ts };
-    }
-
-    /// Quickly compares two instances between each other.
-    pub fn order(self: Instant, other: Instant) std.math.Order {
-        var ord = std.math.order(self.timestamp.sec, other.timestamp.sec);
-        if (ord == .eq) {
-            ord = std.math.order(self.timestamp.nsec, other.timestamp.nsec);
-        }
-        return ord;
-    }
-
-    /// Returns elapsed time in nanoseconds since the `earlier` Instant.
-    /// This assumes that the `earlier` Instant represents a moment in time before or equal to `self`.
-    /// This also assumes that the time that has passed between both Instants fits inside a u64 (~585 yrs).
-    pub fn since(self: Instant, earlier: Instant) u64 {
-        // Convert timespec diff to ns
-        const seconds: u64 = @intCast(self.timestamp.sec - earlier.timestamp.sec);
-        const elapsed = (seconds * ns_per_s) + @as(u32, @intCast(self.timestamp.nsec));
-        return elapsed - @as(u32, @intCast(earlier.timestamp.nsec));
+        return .{ .timestamp = posix.clock_gettime(clock_id) catch return error.Unsupported };
     }
 };
 
 // this is adapted from std.time.Timer
 pub const Timer = struct {
-    clock_id: posix.clockid_t,
-    started: Instant,
-    previous: Instant,
+    clock: Clock,
+    started: std.time.Instant,
+    previous: std.time.Instant,
 
     pub const Error = error{TimerUnsupported};
 
     /// Initialize the timer by querying for a supported clock.
     /// Returns `error.TimerUnsupported` when such a clock is unavailable.
     /// This should only fail in hostile environments such as linux seccomp misuse.
-    pub fn start(clock_id: posix.clockid_t) Error!Timer {
-        const current = Instant.now(clock_id) catch return error.TimerUnsupported;
-        return Timer{ .clock_id = clock_id, .started = current, .previous = current };
+    pub fn start(clock: Clock) Error!Timer {
+        const current = clock.now() catch return error.TimerUnsupported;
+        return Timer{ .clock = clock, .started = current, .previous = current };
     }
 
     /// Reads the timer value since start or the last reset in nanoseconds.
@@ -93,8 +60,8 @@ pub const Timer = struct {
 
     /// Returns an Instant sampled at the callsite that is
     /// guaranteed to be monotonic with respect to the timer's starting point.
-    fn sample(self: *Timer) Instant {
-        const current = Instant.now(self.clock_id) catch unreachable;
+    fn sample(self: *Timer) std.time.Instant {
+        const current = self.clock.now() catch unreachable;
         if (current.order(self.previous) == .gt) {
             self.previous = current;
         }


### PR DESCRIPTION
Heyo! just some adjustments I had to make to be able to use zubench.
`c17c38c` was probably uncaught because CI only references the `*Inner` versions of the API.
`d3457b5` I just relied on `std`'s `Instant` to support windows. FYI initially I tried to add `.process` and `.thread` clock support but turns out `ProcessTimes` and `ThreadTimes` record in a 15ms intervals and skip I/O and sleep/suspension so I abandoned it.